### PR TITLE
Use source as the dst for go-getter

### DIFF
--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -157,7 +157,13 @@ func (t *Tree) Load(s getter.Storage, mode GetMode) error {
 		// Get the directory where this module is so we can load it
 		key := strings.Join(path, ".")
 		key = "root." + key
-		dir, ok, err := getStorage(s, key, source, mode)
+
+		// Altering this to pass source as the key to go-getter
+		//
+		// This was changed in https://github.com/hashicorp/terraform/pull/1418
+		// to support cross platform pushes, we don't need this and prefer
+		// the performance improvement from the old method
+		dir, ok, err := getStorage(s, source, source, mode)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
An md5 hash of the dst is used as the folder name on disk.

In https://github.com/hashicorp/terraform/pull/1418 this was altered
to not be platform specific. The dst was changed from the source to a
key based on the module path. This was done so that terraform push
would work. This had the side affect that modules with the same source
would result in multiple downloads. This was acknowledged in the original
commit.

This is a simple way to have the key be based on source again.

Tested with terraform get and all works ok. With terraform get --update
the update is done multiple times as if the 1:1 mapping was still in
place.
