### PR TITLE
ultradns_dirpool.conflict_resolve: fix default from response

### DIFF
--- a/builtin/providers/ultradns/resource_ultradns_dirpool.go
+++ b/builtin/providers/ultradns/resource_ultradns_dirpool.go
@@ -394,7 +394,13 @@ func populateResourceFromDirpool(d *schema.ResourceData, r *udnssdk.RRSet) error
 
 	// Set simple values
 	d.Set("description", p.Description)
-	d.Set("conflict_resolve", p.ConflictResolve)
+
+	// Ensure default looks like "GEO", even when nothing is returned
+	if p.ConflictResolve == "" {
+		d.Set("conflict_resolve", "GEO")
+	} else {
+		d.Set("conflict_resolve", p.ConflictResolve)
+	}
 
 	rd := makeSetFromDirpoolRdata(r.RData, p.RDataInfo)
 	err = d.Set("rdata", rd)


### PR DESCRIPTION
UltraDNS REST API User Guide claims that "Directional Pool
Profile Fields" have a "conflictResolve" field which "If not
specified, defaults to GEO."
https://portal.ultradns.com/static/docs/REST-API_User_Guide.pdf

But UltraDNS does not actually return a conflictResolve
attribute when it has been updated to "GEO".

We could fix it in udnssdk, but that would require either:
- hide the response by coercing "" to "GEO" for everyone
- use a pointer to allow checking for nil (requires all
  users to change if they fix this)

An ideal solution would be to have the UltraDNS API respond
with this attribute for every dirpool's rdata.

So at the risk of foolish consistency in the sdk, we're
going to solve it where it's visible to the user:
by checking and overriding the parsing. I'm sorry.
