### PR TITLE
ultradns_record: convert rdata to set

### DIFF
--- a/builtin/providers/ultradns/resource_ultradns_record.go
+++ b/builtin/providers/ultradns/resource_ultradns_record.go
@@ -28,7 +28,7 @@ func newRRSetResource(d *schema.ResourceData) (rRSetResource, error) {
 	}
 
 	if attr, ok := d.GetOk("rdata"); ok {
-		rdata := attr.([]interface{})
+		rdata := attr.(*schema.Set).List()
 		r.RData = make([]string, len(rdata))
 		for i, j := range rdata {
 			r.RData[i] = j.(string)
@@ -47,7 +47,7 @@ func populateResourceDataFromRRSet(r udnssdk.RRSet, d *schema.ResourceData) erro
 	// ttl
 	d.Set("ttl", r.TTL)
 	// rdata
-	err := d.Set("rdata", r.RData)
+	err := d.Set("rdata", makeSetFromStrings(r.RData))
 	if err != nil {
 		return fmt.Errorf("ultradns_record.rdata set failed: %#v", err)
 	}
@@ -89,7 +89,8 @@ func resourceUltradnsRecord() *schema.Resource {
 				ForceNew: true,
 			},
 			"rdata": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
+				Set:      schema.HashString,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/builtin/providers/ultradns/resource_ultradns_record_test.go
+++ b/builtin/providers/ultradns/resource_ultradns_record_test.go
@@ -25,7 +25,7 @@ func TestAccUltradnsRecord(t *testing.T) {
 					testAccCheckUltradnsRecordExists("ultradns_record.it", &record),
 					resource.TestCheckResourceAttr("ultradns_record.it", "zone", domain),
 					resource.TestCheckResourceAttr("ultradns_record.it", "name", "test-record"),
-					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.0", "10.5.0.1"),
+					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.3994963683", "10.5.0.1"),
 				),
 			},
 			resource.TestStep{
@@ -34,7 +34,7 @@ func TestAccUltradnsRecord(t *testing.T) {
 					testAccCheckUltradnsRecordExists("ultradns_record.it", &record),
 					resource.TestCheckResourceAttr("ultradns_record.it", "zone", domain),
 					resource.TestCheckResourceAttr("ultradns_record.it", "name", "test-record"),
-					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.0", "10.5.0.1"),
+					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.3994963683", "10.5.0.1"),
 				),
 			},
 			resource.TestStep{
@@ -43,7 +43,7 @@ func TestAccUltradnsRecord(t *testing.T) {
 					testAccCheckUltradnsRecordExists("ultradns_record.it", &record),
 					resource.TestCheckResourceAttr("ultradns_record.it", "zone", domain),
 					resource.TestCheckResourceAttr("ultradns_record.it", "name", "test-record"),
-					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.0", "10.5.0.2"),
+					resource.TestCheckResourceAttr("ultradns_record.it", "rdata.1998004057", "10.5.0.2"),
 				),
 			},
 		},


### PR DESCRIPTION
UltraDNS does not store the ordering of rdata elements, so we need a way
to identify if changes have been made even it the order changes.
A perfect job for schema.Set.
